### PR TITLE
Fix: Resolve task conflict on concurrent downloads

### DIFF
--- a/app/src/main/java/com/neoruaa/xhsdn/viewmodels/MainViewModel.kt
+++ b/app/src/main/java/com/neoruaa/xhsdn/viewmodels/MainViewModel.kt
@@ -198,45 +198,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             )
         }
 
-        // 在协程外部立即创建任务并设置currentTaskId，以便外部可以立即访问
-        val initialTaskId = if (currentTaskId > 0) {
-            // If we already have a task ID (e.g., from copyDescription), update the existing task
-            val existingTask = TaskManager.getTaskById(currentTaskId)
-            if (existingTask != null) {
-                // Update the existing task with new info
-                TaskManager.updateTask(currentTaskId) { task ->
-                    task.copy(
-                        noteUrl = targetUrl,
-                        noteTitle = task.noteTitle ?: extractTitleFromUrl(targetUrl), // Use existing title or extract from URL
-                        noteType = NoteType.IMAGE,
-                        totalFiles = 1, // We'll update this later after getting the count
-                        status = TaskStatus.QUEUED
-                    )
-                }
-                TaskManager.startTask(currentTaskId)
-                currentTaskId
-            } else {
-                // If somehow the task doesn't exist, create a new one
-                val newTaskId = TaskManager.createTask(
-                    noteUrl = targetUrl,
-                    noteTitle = extractTitleFromUrl(targetUrl),
-                    noteType = NoteType.IMAGE,
-                    totalFiles = 1 // We'll update this later after getting the count
-                )
-                TaskManager.startTask(newTaskId)
-                newTaskId
-            }
-        } else {
-            // Create a new task if no currentTaskId exists
-            val newTaskId = TaskManager.createTask(
-                noteUrl = targetUrl,
-                noteTitle = extractTitleFromUrl(targetUrl),
-                noteType = NoteType.IMAGE,
-                totalFiles = 1 // We'll update this later after getting the count
-            )
-            TaskManager.startTask(newTaskId)
-            newTaskId
-        }
+        // 在协程外部立即创建新任务并设置currentTaskId，以便外部可以立即访问
+        val initialTaskId = TaskManager.createTask(
+            noteUrl = targetUrl,
+            noteTitle = extractTitleFromUrl(targetUrl),
+            noteType = NoteType.IMAGE,
+            totalFiles = 1 // We'll update this later after getting the count
+        )
+        TaskManager.startTask(initialTaskId)
 
         currentTaskId = initialTaskId
         // 重置任务跟踪计数器


### PR DESCRIPTION
When initiating a new download while an existing one is still in progress, the previous task is interrupted but its ID is incorrectly reused due to asynchronous cancellation delays. This results in the new download's records being merged into the old task's history. This PR removes the incorrect task ID reuse logic in `startDownload()`, ensuring that every new download request unconditionally creates a fresh task and its own independent record.