### PR TITLE
feat: add Keep Screen On toggle in Settings

### DIFF
--- a/app/src/main/java/com/neoruaa/xhsdn/MainActivity.kt
+++ b/app/src/main/java/com/neoruaa/xhsdn/MainActivity.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.provider.Settings
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.core.view.WindowCompat
 import androidx.activity.ComponentActivity
@@ -143,6 +144,12 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         com.neoruaa.xhsdn.data.TaskManager.init(this)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        // 防止自动锁屏
+        val prefs = getSharedPreferences("XHSDownloaderPrefs", MODE_PRIVATE)
+        if (prefs.getBoolean("keep_screen_on", false)) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
         setContent {
             val controller = ThemeController(ColorSchemeMode.System)
             val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -174,6 +181,12 @@ class MainActivity : ComponentActivity() {
                 val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
                     if (key == "manual_input_links") {
                         manualInputLinks = prefs.getBoolean("manual_input_links", false)
+                    } else if (key == "keep_screen_on") {
+                        if (prefs.getBoolean("keep_screen_on", false)) {
+                            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                        } else {
+                            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+                        }
                     }
                 }
                 prefs.registerOnSharedPreferenceChangeListener(listener)

--- a/app/src/main/java/com/neoruaa/xhsdn/SettingsActivity.kt
+++ b/app/src/main/java/com/neoruaa/xhsdn/SettingsActivity.kt
@@ -83,6 +83,7 @@ data class SettingsUiState(
     val template: TextFieldValue = TextFieldValue(NamingFormat.DEFAULT_TEMPLATE),
     val tokens: List<NamingFormat.TokenDefinition> = emptyList(),
     val debugNotificationEnabled: Boolean = false,
+    val keepScreenOn: Boolean = false,
     val showClipboardBubble: Boolean = true,
     val autoReadClipboard: Boolean = false,
     val manualInputLinks: Boolean = false
@@ -103,6 +104,7 @@ class SettingsViewModel(private val prefs: SharedPreferences) : ViewModel() {
             template = NamingFormat.DEFAULT_TEMPLATE
         }
         val debugNotificationEnabled = prefs.getBoolean("debug_notification_enabled", false)
+        val keepScreenOn = prefs.getBoolean("keep_screen_on", false)
         val showClipboardBubble = prefs.getBoolean("show_clipboard_bubble", true) // Default true
         val autoReadClipboard = prefs.getBoolean("auto_read_clipboard", false)
         val manualInputLinks = prefs.getBoolean("manual_input_links", false)
@@ -112,6 +114,7 @@ class SettingsViewModel(private val prefs: SharedPreferences) : ViewModel() {
             template = TextFieldValue(template),
             tokens = NamingFormat.getAvailableTokens(),
             debugNotificationEnabled = debugNotificationEnabled,
+            keepScreenOn = keepScreenOn,
             showClipboardBubble = showClipboardBubble,
             autoReadClipboard = autoReadClipboard,
             manualInputLinks = manualInputLinks
@@ -152,6 +155,12 @@ class SettingsViewModel(private val prefs: SharedPreferences) : ViewModel() {
         }
     }
 
+    fun onKeepScreenOnChange(enabled: Boolean) = updateState {
+        it.copy(keepScreenOn = enabled).also { newState ->
+            persist(newState)
+        }
+    }
+
     fun onShowClipboardBubbleChange(enabled: Boolean) = updateState {
         it.copy(showClipboardBubble = enabled).also { newState ->
             persist(newState)
@@ -177,6 +186,7 @@ class SettingsViewModel(private val prefs: SharedPreferences) : ViewModel() {
             .putBoolean("use_custom_naming_format", state.useCustomNaming)
             .putString("custom_naming_template", state.template.text.ifBlank { NamingFormat.DEFAULT_TEMPLATE })
             .putBoolean("debug_notification_enabled", state.debugNotificationEnabled)
+            .putBoolean("keep_screen_on", state.keepScreenOn)
             .putBoolean("show_clipboard_bubble", state.showClipboardBubble)
             .putBoolean("auto_read_clipboard", state.autoReadClipboard)
             .putBoolean("manual_input_links", state.manualInputLinks)
@@ -244,6 +254,7 @@ class SettingsActivity : ComponentActivity() {
                     onTemplateChange = viewModel::onTemplateChange,
                     onResetTemplate = viewModel::onResetTemplate,
                     onDebugNotificationChange = viewModel::onDebugNotificationChange,
+                    onKeepScreenOnChange = viewModel::onKeepScreenOnChange,
                     onShowClipboardBubbleChange = viewModel::onShowClipboardBubbleChange,
                     onAutoReadClipboardChange = viewModel::onAutoReadClipboardChange,
                     onManualInputLinksChange = viewModel::onManualInputLinksChange,
@@ -278,6 +289,7 @@ private fun SettingsScreen(
     onTemplateChange: (TextFieldValue) -> Unit,
     onResetTemplate: () -> Unit,
     onDebugNotificationChange: (Boolean) -> Unit,
+    onKeepScreenOnChange: (Boolean) -> Unit,
     onShowClipboardBubbleChange: (Boolean) -> Unit,
     onAutoReadClipboardChange: (Boolean) -> Unit,
     onManualInputLinksChange: (Boolean) -> Unit,
@@ -340,6 +352,13 @@ private fun SettingsScreen(
                         description = stringResource(R.string.debug_notifications_desc),
                         checked = uiState.debugNotificationEnabled,
                         onCheckedChange = onDebugNotificationChange
+                    )
+
+                    MiuixSwitchWidget(
+                        title = stringResource(R.string.keep_screen_on),
+                        description = stringResource(R.string.keep_screen_on_desc),
+                        checked = uiState.keepScreenOn,
+                        onCheckedChange = onKeepScreenOnChange
                     )
                 }
             }

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -79,6 +79,8 @@
     <string name="create_live_photos_desc">關閉後 Live Photo 將作為圖片+影片分別下載</string>
     <string name="debug_notifications">調試通知</string>
     <string name="debug_notifications_desc">顯示詳細的下載調試資訊</string>
+    <string name="keep_screen_on">保持螢幕常亮</string>
+    <string name="keep_screen_on_desc">App 在前台時防止手機自動鎖定螢幕</string>
 
     <!-- Clipboard option strings -->
     <string name="show_clipboard_bubble">顯示剪貼簿氣泡</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -79,6 +79,8 @@
     <string name="create_live_photos_desc">关闭后 Live Photo 将作为图片+视频分别下载</string>
     <string name="debug_notifications">调试通知</string>
     <string name="debug_notifications_desc">显示详细的下载调试信息</string>
+    <string name="keep_screen_on">保持屏幕常亮</string>
+    <string name="keep_screen_on_desc">App 在前台时防止手机自动锁屏</string>
 
     <!-- Clipboard option strings -->
     <string name="show_clipboard_bubble">显示剪贴板气泡</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,8 @@
     <string name="create_live_photos_desc">Live Photos will be saved as image+video separately when disabled</string>
     <string name="debug_notifications">Debug Notifications</string>
     <string name="debug_notifications_desc">Show detailed download debugging information</string>
+    <string name="keep_screen_on">Keep Screen On</string>
+    <string name="keep_screen_on_desc">Prevent the phone from auto-locking while the app is in the foreground</string>
 
     <!-- Clipboard option strings -->
     <string name="show_clipboard_bubble">Show Clipboard Bubble</string>


### PR DESCRIPTION
## What

Add a new **"Keep Screen On"** (保持屏幕常亮) toggle in Settings → Download Options.

When enabled, the app prevents the phone from auto-locking while in the foreground.

## How

Uses `FLAG_KEEP_SCREEN_ON` on the Activity window — the [official Android recommended approach](https://developer.android.com/develop/background-work/services/screen-on):

- ✅ No extra permissions required
- ✅ Automatically disabled when the app goes to background (no resource leak)
- ✅ Compatible with all Android versions (API 1+)
- ✅ Real-time response when toggled in Settings (no app restart needed)

## Changes

| File | Change |
|------|--------|
| `SettingsActivity.kt` | Add `keepScreenOn` state field, ViewModel load/persist/change handler, UI switch |
| `MainActivity.kt` | Apply/clear `FLAG_KEEP_SCREEN_ON` on startup and on preference change |
| `strings.xml` (en) | Add `keep_screen_on` / `keep_screen_on_desc` |
| `strings.xml` (zh-CN) | 保持屏幕常亮 / App 在前台时防止手机自动锁屏 |
| `strings.xml` (zh-TW) | 保持螢幕常亮 / App 在前台時防止手機自動鎖定螢幕 |

## Testing

Tested on Xiaomi 23116PN5BC:
- [x] Toggle appears in Settings → Download Options
- [x] Screen stays on when enabled and app is in foreground
- [x] Screen auto-locks normally when disabled
- [x] Screen auto-locks when app is in background (even if enabled)
- [x] Toggle change takes effect immediately without app restart